### PR TITLE
Better Chat Coloring and Staff Titles

### DIFF
--- a/clublink.sh
+++ b/clublink.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-if [ -d "./node_modules" ]
-then
-    ts-node ./src/index.ts --gui --chat
-else
-    npm i
-    npm i -g typescript
-fi

--- a/clublink.sh
+++ b/clublink.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [ -d "./node_modules" ]
+then
+    ts-node ./src/index.ts --gui --chat
+else
+    npm i
+    npm i -g typescript
+fi

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,12 +166,35 @@ ConsoleCosmeticLib.startUpSequence(() => {
 
     Minecraft.on("messagestr", async (message, messagePosition, jsonMsg) => {
 
-        const formattedMessage = message.replace(sequences.ADMIN_TITLE, " [Admin]").replace(/[^a-zA-Z0-9 &/$£"^%&{}[\]@,<>/`!?~#:;\-_=+*.]/g, "").replace(Minecraft.username, colors.blue(Minecraft.username)).replace("@everyone", colors.yellow("@everyone")).replace(Minecraft.username, colors.blue(Minecraft.username)).replace("@everyone", colors.yellow("@everyone"));
+        const formattedMessage = message
+            .replace(sequences.MOD_TITLE, " [Mod]")
+            .replace(sequences.ADMIN_TITLE, " [Admin]")
+            .replace(sequences.MANAGER_TITLE, " [Manager]")
+            .replace(sequences.OWNER_TITLE, " [Owner]")
+            .replace(/[^a-zA-Z0-9 &/$£"^%&{}[\]@,<>/`!?~#:;\-_=+*.]/g, "")
+            .replace(Minecraft.username, colors.blue(Minecraft.username))
+            .replace("@everyone", colors.yellow("@everyone"))
+            .replace(Minecraft.username, colors.blue(Minecraft.username))
+            .replace("@everyone", colors.yellow("@everyone"));
 
         if (formattedMessage.length < 8) {
             console.log(colors.magenta("[#]") + colors.gray(" Console Message - IGNORE"));
         } else {
-            console.log(colors.cyan("[<]") + colors.cyan(formattedMessage));
+            var chatMsg = formattedMessage.split(":");
+            if(chatMsg[1] === undefined) {  // when receiving tokens, game duel request, etc. (so it would show "undefinded")
+                console.log(colors.cyan("[<] " + formattedMessage));
+            } else {
+                console.log(
+                    colors.cyan("[<]") +
+                    colors.yellow(chatMsg[0]
+                        .replace(" [Mod]", colors.green(" [Mod]"))
+                        .replace(" [Admin]", colors.red(" [Admin]"))
+                        .replace(" [Manager]", colors.red(" [Manager]"))
+                        .replace(" [Owner]", colors.red(" [Owner]"))
+                    ) + ":" +
+                    colors.cyan(chatMsg[1])
+                );
+            }
         }
 
         

--- a/src/resources/sequences.ts
+++ b/src/resources/sequences.ts
@@ -3,5 +3,5 @@ export default {
     BETA_TITLE: "ꌄ섆魉胩뜇穙慵ꈂ怡ꈂ恢ꈂ忧",
     MOD_TITLE: "ꌄ섆魉쌇뜆醭愃ꈂ愭ꈂ匀",
     MANAGER_TITLE: "ꌄ섆魉쌈뜈ꈋ愃忧惋忧悈怡愤",
-    OWNER_TITLE: "ꌄ섆魉쌆ꌄ뜈醋ꑝꑝ 愭ꈂ肄ꈂ惋ꈂ怡ꈂ愤",
+    OWNER_TITLE: "ꌄ섆魉쌆뜈ꈋ愭ꈂ肄ꈂ惋ꈂ怡ꈂ愤",
 };


### PR DESCRIPTION
- Changed chat coloring from cyan only to yellow (for player names) and cyan (for the chat messages).
- Added Mod, Manager, and Owner title prefix.
- Fixed Owner unique title code.
- Added green color for Mod title prefix and red color for Admin, Manager, and Owner.