### PR TITLE
Critical security fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@types/centra": "^2.2.0",
     "@types/figlet": "^1.5.4",
     "centra": "^2.5.0",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "discord.js": "^13.5.0",
     "dotenv": "^10.0.0",
     "figlet": "^1.5.2",


### PR DESCRIPTION
Recent security issues with the latest version of the colors package mean that v1.4.0 is needed to prevent problems. Sorry for little detail, am typing on mobile & it's cold